### PR TITLE
Enable localization

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,13 @@
 import { useState, useEffect } from 'react';
 import { RefTaggerSettings } from './interfaces';
 
-const addScript = (setScriptAdded: React.Dispatch<React.SetStateAction<boolean>>): void => {
+const addScript = (setScriptAdded: React.Dispatch<React.SetStateAction<boolean>>, language?: string): void => {
   setScriptAdded(true);
   const el = document.createElement('script');
   el.type = 'text/javascript';
   el.async = true;
-  el.src = 'https://api.reftagger.com/v2/RefTagger.js';
+  const suffix = language ? `.${language}.js` : '.js';
+  el.src = `https://api.reftagger.com/v2/RefTagger${suffix}`;
   document.getElementsByTagName('body')[0].appendChild(el);
 };
 
@@ -19,7 +20,7 @@ export const RefTagger = (props: RefTaggerSettings): null => {
 
   useEffect(() => {
     if (!scriptAdded) {
-      addScript(setScriptAdded);
+      addScript(setScriptAdded, props.language);
     }
     if (window && !window.refTagger) {
       addRefTagger(props);

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,6 +25,7 @@ export interface RefTaggerSettings {
   convertHyperlinks?: boolean;
   customStyle?: CustomStyle;
   dropShadow?: boolean;
+  language?: 'de' | 'en' | 'es' | 'fr' | 'ko' | string;
   linksOpenNewWindow?: boolean;
   logosLinkIcon?: 'dark' | 'light';
   noSearchClassNames?: string[];


### PR DESCRIPTION
#### Summary

Adds 'language' setting to RefTagger, which enables localization for languages which are supported by the reference tagger API.

Added everyone who contributed to this so far as co-authors. Teamwork makes the dream work :blush:

Closes #9
Closes #10