### PR TITLE
Correct 'language' setting with supported languages

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -25,7 +25,7 @@ export interface RefTaggerSettings {
   convertHyperlinks?: boolean;
   customStyle?: CustomStyle;
   dropShadow?: boolean;
-  language?: 'de' | 'en' | 'es' | 'fr' | 'ko' | string;
+  language?: 'en' | 'es' | string;
   linksOpenNewWindow?: boolean;
   logosLinkIcon?: 'dark' | 'light';
   noSearchClassNames?: string[];


### PR DESCRIPTION
**Summary**

Currently, the only supported languages noted in the public documentation are English & Spanish. This change corrects that for the 'language' setting for RefTagger.

**References**

- [David's message on officially supported languages.](https://github.com/Faithlife/react-reftagger/pull/11#issuecomment-965737499)
- [Faithlife's RefTagger FAQ, which states their officially supported languages.](https://faithlife.com/products/reftagger/faq)